### PR TITLE
feature(util/random): generate random bytes

### DIFF
--- a/util/random.go
+++ b/util/random.go
@@ -10,7 +10,7 @@ import (
 
 // BytesGenerator is a random bytes generator. We use it to generate random
 // sequences of characters in the NDT test. BytesGenerator implements optimized
-// techniques described in https://stackoverflow.com/a/12321192. One issue of
+// techniques described in https://stackoverflow.com/a/31832326. One issue of
 // BytesGenerator is that it's not multi-goroutine safe. When serving a client
 // with multiple goroutines, create a BytesGenerator per goroutine!
 type BytesGenerator struct {

--- a/util/random.go
+++ b/util/random.go
@@ -1,0 +1,85 @@
+// Part of ndt-server-go <https://github.com/m-lab/ndt-server-go>, which
+// is free software under the Apache v2.0 License.
+
+package util
+
+import (
+	"math/rand"
+	"time"
+)
+
+// BytesGenerator is a random bytes generator. We use it to generate random
+// sequences of characters in the NDT test. BytesGenerator implements optimized
+// techniques described in https://stackoverflow.com/a/12321192. One issue of
+// BytesGenerator is that it's not multi-goroutine safe. When serving a client
+// with multiple goroutines, create a BytesGenerator per goroutine!
+type BytesGenerator struct {
+	src rand.Source
+}
+
+// NewBytesGenerator returns a BytesGenerator. It seeds the internal randomness
+// source with the current time, so you do not have to worry about that.
+func NewBytesGenerator() BytesGenerator {
+	return BytesGenerator{
+		src: rand.NewSource(time.Now().UnixNano()),
+	}
+}
+
+// GenLettersFast generates a |n| sized bytes vector containing only ASCII
+// uppercase and lowercase letters chosen at random. The algorithm used
+// by this function is the fastest according to the above mentioned thread
+// on Stack Overflow. Yet, it is not flexible in that it is specifically
+// optimized for only returning a character in a 52 characters set.
+func (bgen BytesGenerator) GenLettersFast(n int) []byte {
+	if n <= 0 {
+		return make([]byte, 0)
+	}
+
+	// WARNING: don't change this variable without changing also the
+	// algorithm to work with a string of different length!
+	const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	const (
+		// 6 bits to represent a letter index
+		letterIdxBits = 6
+		// All 1-bits, as many as letterIdxBits
+		letterIdxMask = 1 << (letterIdxBits - 1)
+		// Number of letter indices fitting in 63 bits
+		letterIdxMax = 63 / letterIdxBits
+	)
+
+	source := bgen.src
+	b := make([]byte, n)
+
+	// A rand.Int63() generates 63 random bits, enough for
+	// letterIdxMax characters!
+	for i, cache, remain := n-1, source.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = source.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return b
+}
+
+// GenAnythingSlow generates a |n| sized bytes vector containing only chars
+// that appear within |input|, chosen at random. According to the above
+// mentioned Stack Overflow thread, this is one of the slowest methods to
+// generate random bytes, but we include it because it's flexible.
+func (bgen BytesGenerator) GenAnythingSlow(n int, input []byte) []byte {
+	if n <= 0 {
+		return make([]byte, 0)
+	}
+	source := bgen.src
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = input[source.Int63()%int64(len(input))]
+	}
+	return b
+}

--- a/util/random_test.go
+++ b/util/random_test.go
@@ -1,0 +1,57 @@
+// Part of ndt-server-go <https://github.com/m-lab/ndt-server-go>, which
+// is free software under the Apache v2.0 License.
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+// TestApiWorks makes sure that we correctly deal with all the possible
+// range of input parameters and produce consistent output.
+func TestApiWorks(t *testing.T) {
+	check := func(f func(BytesGenerator, int) []byte) {
+		bgen := NewBytesGenerator()
+		o := f(bgen, -128)
+		if len(o) != 0 {
+			t.Error("cannot deal with negative input")
+		}
+		o = f(bgen, 0)
+		if len(o) != 0 {
+			t.Error("cannot deal with zero input")
+		}
+		o = f(bgen, 512)
+		if len(o) != 512 {
+			t.Error("cannot deal with positive input")
+		}
+	}
+	check(func(bgen BytesGenerator, n int) []byte {
+		return bgen.GenLettersFast(n)
+	})
+	check(func(bgen BytesGenerator, n int) []byte {
+		return bgen.GenAnythingSlow(n, []byte("ABCDEabcdeZz"))
+	})
+}
+
+// TestIsSeeded makes sure that two subsequently created generators
+// do not typically generate equal random sequences. There may possibly
+// some cases in which this could fail (i.e. the clock jumping back
+// because of some cloud hiccups). I added a sleep in here to reduce
+// the likelyhood of that, but stil it may fail sometimes.
+func TestIsSeeded(t *testing.T) {
+	check := func(f func(BytesGenerator, int) []byte) {
+		first := NewBytesGenerator()
+		time.Sleep(100 * time.Millisecond) // Be sure
+		second := NewBytesGenerator()
+		if string(f(first, 1024)) == string(f(second, 1024)) {
+			t.Error("seems we are not seeded")
+		}
+	}
+	check(func(bgen BytesGenerator, n int) []byte {
+		return bgen.GenLettersFast(n)
+	})
+	check(func(bgen BytesGenerator, n int) []byte {
+		return bgen.GenAnythingSlow(n, []byte("ABCDEabcdeZz"))
+	})
+}


### PR DESCRIPTION
We need this feature to send random bytes over the wire.

Compared to the github.com/neubot/botticelli implementation, this one
is more modular and most likely also more efficient.

Unlike botticelli, here we use directly an unlocked random source, which
is the fastest way of getting randomness.

There are two possibilities: generate random A-Za-z letters (what NDT
really needs) at maximum speed, and generate random bytes in a specific
set of bytes using a much slower generator algorithm.

The original copyright (which I mostly own) is gone since in the end
this is an implementation from scratch of a similar concept.

This commit also adds docstrings and (passing) tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server-go/18)
<!-- Reviewable:end -->
