### PR TITLE
Implement NewTCPListenerWithDeadline()

### DIFF
--- a/netx/netx.go
+++ b/netx/netx.go
@@ -67,8 +67,7 @@ func (dc DeadlineConn) Write(data []byte) (int, error) {
 
 // NewTCPListenerWithDeadline constructs a TCPListener that has a specific
 // deadline after which all pending Accept()s will fail.
-func NewTCPListenerWithDeadline(
-	address string, deadline time.Time) (net.Listener, error) {
+func NewTCPListenerWithDeadline(address string, deadline time.Time) (net.Listener, error) {
 	listener, err := net.Listen("tcp", address)
 	if err != nil {
 		return nil, err

--- a/netx/netx.go
+++ b/netx/netx.go
@@ -17,14 +17,14 @@ type DeadlineConn struct {
 	timeout time.Duration
 }
 
-// DefaultDeadlineConnTimeout is the default timeout used by DeadlineConn.
-const DefaultDeadlineConnTimeout = 10.0 * time.Second
+// DefaultTimeout is the default timeout used by DeadlineConn.
+const DefaultTimeout = 10.0 * time.Second
 
 // NewDeadlineConn creates a new DeadlineConn.
 func NewDeadlineConn(conn net.Conn) DeadlineConn {
 	return DeadlineConn{
 		Conn:    conn,
-		timeout: DefaultDeadlineConnTimeout,
+		timeout: DefaultTimeout,
 	}
 }
 
@@ -63,4 +63,20 @@ func (dc DeadlineConn) Write(data []byte) (int, error) {
 	// don't bother with resetting the deadline since it will be set
 	// again next time we call Write()
 	return dc.Conn.Write(data)
+}
+
+// NewTCPListenerWithDeadline constructs a TCPListener that has a specific
+// deadline after which all pending Accept()s will fail.
+func NewTCPListenerWithDeadline(
+	address string, deadline time.Time) (net.Listener, error) {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, err
+	}
+	err = listener.(*net.TCPListener).SetDeadline(deadline)
+	if err != nil {
+		listener.Close()
+		return nil, err
+	}
+	return listener, nil
 }


### PR DESCRIPTION
1. when we are waiting for a client to connect for C2S or S2C, we need
   to Accept() only for a few seconds and then return an error

2. so, introduce a wrapper constructor for net.TCPListener that will
   also set a maximum deadline for Accept()

3. while there, rename the variable indicating the default timeout to be
   shorter because currently it was really too long

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server-go/23)
<!-- Reviewable:end -->
