### PR TITLE
protocol.go: remove TestCode

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -46,7 +46,7 @@ const (
 	MsgLogout
 	// MsgWaiting tells a server that a client is alive.
 	MsgWaiting
-	// MsgExtendedLogin is the JSON-protocol loging message.
+	// MsgExtendedLogin is the JSON-protocol login message.
 	MsgExtendedLogin
 )
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -16,9 +16,6 @@ import (
 
 // Spec: https://github.com/ndt-project/ndt/wiki/NDTProtocol
 
-// TestCode is used to decode the tests bitvector.
-type TestCode int
-
 // Message types. Note: compared to the original specification, I have added
 // the `Msg` prefix to all messages not having it for clarity. Also, the
 // TEST_MSG define is mapped onto the MsgTest constant.
@@ -54,7 +51,7 @@ const (
 
 const (
 	// TestMid is the middle boxes test.
-	TestMid TestCode = 1 << iota
+	TestMid = 1 << iota
 	// TestC2S is the single-stream upload test.
 	TestC2S
 	// TestS2C is the single-stream download test.


### PR DESCRIPTION
The botticelli code assumes that TestCode is an int. I think we can
safely keep that assumption. Otherwise, if Greg does not like this
way of proceeding, we can revert this diff and add casts.

Depends on #24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server-go/25)
<!-- Reviewable:end -->
