### PR TITLE
refactor(protocol.go): sniff for WebSockets during Login

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -167,10 +167,14 @@ func ReadLogin(brdr *bufio.Reader) (Login, error) {
 		return Login{}, ErrIllegalMessageHeader
 	}
 
+	// Not WebSockets, then we can read an ordinary message.
+
 	msg, err := ReadMessage(brdr)
 	if err != nil {
 		return Login{}, err
 	}
+
+	// Make sure the message type is legit and further parse it.
 
 	switch msg.Header.MsgType {
 	case MsgLogin:

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -46,7 +46,7 @@ const (
 	MsgLogout
 	// MsgWaiting tells a server that a client is alive.
 	MsgWaiting
-	// MsgExtendedLogin is the JSON-protocol loging message.
+	// MsgExtendedLogin is the JSON-protocol login message.
 	MsgExtendedLogin
 )
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -105,30 +105,8 @@ var ErrIllegalMessageHeader = errors.New("Illegal Message Header")
 func ReadMessage(brdr *bufio.Reader) (Message, error) {
 	// Implementation note: we use a buffered reader, so we're robust to
 	// the case in which we receive a batch of messages.
-	get, err := brdr.Peek(3)
-	if err != nil {
-		log.Println(err)
-		return Message{}, err
-	}
-	if get[0] > MsgExtendedLogin {
-		// TODO(bassosimone):
-		//
-		// If the message is greater than the extended loging message,
-		// we're going to assume that it's a WebSockets connection.
-		//
-		// Probably best way to handle this is to create a new connection
-		// to the websockets handler, and proxy everything from this
-		// connection to the websockets connection.  A little less ugly
-		// than the alternatives.
-		for i := 0; i < 8; i++ {
-			line, _ := brdr.ReadString('\n')
-			log.Printf("%s", string(line))
-		}
-		return Message{}, ErrIllegalMessageHeader
-	}
-
 	var hdr header
-	err = binary.Read(brdr, binary.BigEndian, &hdr)
+	err := binary.Read(brdr, binary.BigEndian, &hdr)
 	if err != nil {
 		log.Println(err)
 		return Message{}, err
@@ -158,7 +136,37 @@ type Login struct {
 }
 
 // ReadLogin reads the initial login message.
+// TODO(bassosimone): this function should become a factory where
+// we receive in input a `*bufio.ReadWriter` and we return, in
+// addition to `(Login, error)` also a `ControlConnection` struct
+// that depends on the protocol used (legacy, JSON, WebSockets).
 func ReadLogin(brdr *bufio.Reader) (Login, error) {
+
+	// Sniff bytes and check whether we're receiving a WebSockets
+	// message rather than a normal NDT message.
+
+	get, err := brdr.Peek(3)
+	if err != nil {
+		log.Println(err)
+		return Login{}, err
+	}
+	if get[0] > MsgExtendedLogin {
+		// TODO(bassosimone):
+		//
+		// If the message is greater than the extended loging message,
+		// we're going to assume that it's a WebSockets connection.
+		//
+		// Probably best way to handle this is to create a new connection
+		// to the websockets handler, and proxy everything from this
+		// connection to the websockets connection.  A little less ugly
+		// than the alternatives.
+		for i := 0; i < 8; i++ {
+			line, _ := brdr.ReadString('\n')
+			log.Printf("%s", string(line))
+		}
+		return Login{}, ErrIllegalMessageHeader
+	}
+
 	msg, err := ReadMessage(brdr)
 	if err != nil {
 		return Login{}, err

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -16,9 +16,6 @@ import (
 
 // Spec: https://github.com/ndt-project/ndt/wiki/NDTProtocol
 
-// TestCode is used to decode the tests bitvector.
-type TestCode int
-
 // Message types. Note: compared to the original specification, I have added
 // the `Msg` prefix to all messages not having it for clarity. Also, the
 // TEST_MSG define is mapped onto the MsgTest constant.
@@ -54,7 +51,7 @@ const (
 
 const (
 	// TestMid is the middle boxes test.
-	TestMid TestCode = 1 << iota
+	TestMid = 1 << iota
 	// TestC2S is the single-stream upload test.
 	TestC2S
 	// TestS2C is the single-stream download test.


### PR DESCRIPTION
I would argue that we don't need to sniff for WebSockets at every
message, rather we want to do that only when reading Login.

In fact, as far as I understand, we should pick a protocol at the
beginning, and then stick to it for the rest of the session.

As such, it only matters to sniff for WebSockets during Login.

Added also a TODO comment explaining how I am planning to go about
further specializing the code next, so Greg can comment on it.

Depends on #25.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-server-go/26)
<!-- Reviewable:end -->
